### PR TITLE
add a waiter that checks for Lambda function state

### DIFF
--- a/ServeRmore.py
+++ b/ServeRmore.py
@@ -55,6 +55,16 @@ class srm:
             S3Bucket=self.cc.settings[env]["aws"]["s3_bucket"],
             S3Key=self.cc.settings[env]["aws"]["s3_key"]+"/"+self.cc.settings[env]["function"]["zip_file_name"]
         )
+        
+        waiter = client.get_waiter('function_updated')
+        waiter.wait(
+            FunctionName=self.cc.settings[env]["function"]["name"],
+            WaiterConfig={
+                'Delay': 5,
+                'MaxAttempts': 60
+            }
+        )
+        
         if self.cc.settings[env]["additional_layer"]["name"]:
             response = client.update_function_configuration(
                 FunctionName=self.cc.settings[env]["function"]["name"],

--- a/VERSION.py
+++ b/VERSION.py
@@ -1,3 +1,3 @@
 #!python3
 
-srm_VERSION = "0.1.1"
+srm_VERSION = "0.1.2"


### PR DESCRIPTION
This PR includes the following change: 
* Add a 'waiter' that checks the Lambda function status during an update

In July 2021, AWS Lambda introduced Lambda function states. When a Lambda function that has been recently created or modified is called, invoked, or requires further configuration, a check is performed to verify that it [the Lambda function] is first in the Active state, and that the LastUpdateStatus is Successful. 

The change introduced in this PR is related to the `srm lambda update` function call. When this function is called, ServeRmore first (1) updates the Lambda function code and then proceeds to update (2) the Lambda function figuration. Without the waiter, it returns the following error: 

> botocore.errorfactory.ResourceConflictException: An error occurred (ResourceConflictException) when calling the UpdateFunctionConfiguration operation: The operation cannot be performed at this time.

The solution was to add the waiter _after_ the call to update the Lambda function code and _before_ the call to update the Lambda function configuration. 