### PR TITLE
ServeRmore v0.1.2

### DIFF
--- a/ServeRmore.py
+++ b/ServeRmore.py
@@ -55,6 +55,16 @@ class srm:
             S3Bucket=self.cc.settings[env]["aws"]["s3_bucket"],
             S3Key=self.cc.settings[env]["aws"]["s3_key"]+"/"+self.cc.settings[env]["function"]["zip_file_name"]
         )
+        
+        waiter = client.get_waiter('function_updated')
+        waiter.wait(
+            FunctionName=self.cc.settings[env]["function"]["name"],
+            WaiterConfig={
+                'Delay': 5,
+                'MaxAttempts': 60
+            }
+        )
+        
         if self.cc.settings[env]["additional_layer"]["name"]:
             response = client.update_function_configuration(
                 FunctionName=self.cc.settings[env]["function"]["name"],

--- a/VERSION.py
+++ b/VERSION.py
@@ -1,3 +1,3 @@
 #!python3
 
-srm_VERSION = "0.1.1"
+srm_VERSION = "0.1.2"


### PR DESCRIPTION
When updating a Lambda function using `srm lambda update`, ServeRmore takes two steps: (1) updating the function code (using [update_function_code](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_code)) and (2) updating the function configuration (using [update_function_configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_configuration)). Since AWS Lambda introduced [Lambda function states](https://docs.aws.amazon.com/lambda/latest/dg/functions-states.html), a waiter must be added between to the two steps to wait until the function has been updated (the function code) before proceeding with further updates (the function configuration). 